### PR TITLE
メソッドのオーバーロードマッチングの衝突を回避するために、プロパティ名が省略可能な方の SetBindingValue を SetBind…

### DIFF
--- a/GuiTestWPF.Net45/MainWindowViewModel.cs
+++ b/GuiTestWPF.Net45/MainWindowViewModel.cs
@@ -29,8 +29,8 @@ namespace GuiTestWPF.Net45
         /// </summary>
         public bool AlphaTestBlockCheckBoxChecked
         {
-            get => this.GetBindingValue<bool>(nameof(this.AlphaTestBlockCheckBoxChecked));
-            set => this.SetBindingValue(nameof(this.AlphaTestBlockCheckBoxChecked), value);
+            get => this.GetBindingValue<bool>();
+            set => this.SetBindingValueQuick(value);
         }
 
         /// <summary>
@@ -38,8 +38,8 @@ namespace GuiTestWPF.Net45
         /// </summary>
         public IChildControlViewModel BravoTestBlockChildViewModel
         {
-            get => this.GetBindingValue<IChildControlViewModel>(nameof(this.BravoTestBlockChildViewModel));
-            set => this.SetBindingValue(nameof(this.BravoTestBlockChildViewModel), value);
+            get => this.GetBindingValue<IChildControlViewModel>();
+            set => this.SetBindingValueQuick(value);
         }
 
         /// <summary>
@@ -47,8 +47,8 @@ namespace GuiTestWPF.Net45
         /// </summary>
         public string CharlieButtonText
         {
-            get => this.GetBindingValue<string>(nameof(this.CharlieButtonText));
-            set => this.SetBindingValue(nameof(this.CharlieButtonText), value);
+            get => this.GetBindingValue<string>();
+            set => this.SetBindingValueQuick(value);
         }
 
 

--- a/LocusCommon.Windows.Controls/InternalViewModels/ImageButtonViewModel.cs
+++ b/LocusCommon.Windows.Controls/InternalViewModels/ImageButtonViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -14,7 +15,8 @@ namespace LocusCommon.Windows.Controls.InternalViewModels
     /// <summary>
     /// 
     /// </summary>
-#if Release
+#if DEBUG == false
+    [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
 #endif
     public class ImageButtonViewModel : ExtendedViewModelBase

--- a/LocusCommon/Windows/ViewModels/ExtendedViewModelBase.cs
+++ b/LocusCommon/Windows/ViewModels/ExtendedViewModelBase.cs
@@ -89,7 +89,7 @@ namespace LocusCommon.Windows.ViewModels
         /// </summary>
         /// <param name="value"></param>
         /// <param name="propertyName">このパラメータは使用されません。</param>
-        protected void SetBindingValue(Object value, [Browsable(false)][CallerMemberName] string propertyName = null)
+        protected void SetBindingValueQuick(Object value, [Browsable(false)][CallerMemberName] string propertyName = null)
         {
             this.SetBindingValue(propertyName, value);
         }


### PR DESCRIPTION
…ingValueQuick へ名称変更


また、これに伴い.NET Framework 4.5向けのWPFサンプルも修正